### PR TITLE
add IterativeMoments + test

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ NB: This package contains also useful methods for performing iterative statistic
 - Shifted mean (see example [here](./tests/unit/test_IterativeMean.py))
 
 
+*About the Iterative higher-order moments* The iterative higher order moments are available as `IterativeMoments` and permit a user to compute higher-order moments up to the 4th order (including skewness and kurtosis). The implementation follows [[5]](#5),
+
+!!! danger "Beware of 4th order"
+    The 4th order (kurtosis) does not pass our tests comparing to Scipy non-iterative Kurtosis calculations. While this is something to beware of, we also test the popular library OpenTurns, which also fails to pass the same test and uses the same equation as us. Follow discussion [here](https://github.com/openturns/openturns/issues/2345).
+
+
 ### Fault-Tolerance 
 For each statistics class, we implement a **save_state()** and **load_from_state()** methods to respectively save the current state and create a new object of type IterativeStatistics from a state object (a python dictionary).
 
@@ -130,3 +136,5 @@ The implementation of the iterative formulas is based on the following papers:
 <a id="3">[3]</a> Philippe Pébay. 2008. Formulas for robust, one-pass parallel computation of covariances and arbitrary-order statistical moments. Sandia Report SAND2008-6212, Sandia National Laboratories 94 (2008).
 
 <a id="4">[4]</a> Iooss, Bertrand, and Jérôme Lonchampt. "Robust tuning of Robbins-Monro algorithm for quantile estimation-Application to wind-farm asset management." ESREL 2021. 2021.
+
+<a id="4">[5]</a>  Meng, Xiangrui. "Simpler online updates for arbitrary-order central moments." arXiv preprint arXiv:1510.04923 (2015). 

--- a/README.md
+++ b/README.md
@@ -137,4 +137,4 @@ The implementation of the iterative formulas is based on the following papers:
 
 <a id="4">[4]</a> Iooss, Bertrand, and Jérôme Lonchampt. "Robust tuning of Robbins-Monro algorithm for quantile estimation-Application to wind-farm asset management." ESREL 2021. 2021.
 
-<a id="4">[5]</a>  Meng, Xiangrui. "Simpler online updates for arbitrary-order central moments." arXiv preprint arXiv:1510.04923 (2015). 
+<a id="5">[5]</a>  Meng, Xiangrui. "Simpler online updates for arbitrary-order central moments." arXiv preprint arXiv:1510.04923 (2015). 

--- a/experimental_design/experiment.py
+++ b/experimental_design/experiment.py
@@ -22,7 +22,6 @@ class AbstractExperiment(ABC):
             else:
                 sample = sample_A
             yield sample
-        
 
     def pick_freeze(self, sample_A: np.array, sample_B : np.array) -> np.array:
         """

--- a/experimental_design/experiment.py
+++ b/experimental_design/experiment.py
@@ -16,9 +16,12 @@ class AbstractExperiment(ABC):
     def generator(self) :
         for _ in range(self.nb_sim):
             sample_A = self.draw()
-            sample_B = self.draw()
-            pick_freeze_sample = self.pick_freeze(sample_A[0], sample_B[0])
-            yield pick_freeze_sample
+            if self.apply_pick_freeze:
+                sample_B = self.draw()
+                sample = self.pick_freeze(sample_A, sample_B)
+            else:
+                sample = sample_A
+            yield sample
         
 
     def pick_freeze(self, sample_A: np.array, sample_B : np.array) -> np.array:

--- a/iterative_stats/iterative_moments.py
+++ b/iterative_stats/iterative_moments.py
@@ -1,24 +1,18 @@
 import numpy as np
 import numpy.typing as npt
-from iterative_stats.iterative_mean import IterativeMean
-from iterative_stats.iterative_variance import IterativeVariance
 from iterative_stats.abstract_iterative_statistics import AbstractIterativeStatistics
 
 
 class IterativeMoments(AbstractIterativeStatistics):
     """
-    This class implements a data structure of moments similar to the one
-    in the original Melissa version
+    Iterative higher order moments following https://arxiv.org/pdf/1510.04923.pdf
+    "Simpler Online Updates for Arbitrary-Order Central Moments"
+    Takes:
+    :param max_order: the maximum order of the moments to compute
     """
     def __init__(self, max_order: int, **kwargs):
         super().__init__(**kwargs)
         self.max_order: int = max_order
-        if self.max_order <= 1:
-            self.iterative_stat = IterativeMean(self.dimension)
-        else:
-            # take lowest primitive possible to avoid duplicating
-            # the mean calculation
-            self.iterative_stat = IterativeVariance(self.dimension)
 
         # Cascading moments depending on the requested max_order
         self.m1: npt.NDArray[np.float_] = np.zeros(self.dimension)
@@ -31,83 +25,55 @@ class IterativeMoments(AbstractIterativeStatistics):
         if self.max_order > 3:
             self.m4: npt.NDArray[np.float_] = np.zeros(self.dimension)
             self.theta4 = np.zeros(self.dimension)
+        if self.max_order > 4:
+            raise NotImplementedError("Moments of order > 4 not implemented")
 
     def increment(self, np_data: npt.NDArray[np.float_]):
-        """
-        This function increments the various orders of moments
-        """
+
         self.iteration += 1
+        delta = self.get_delta(self.m1, np_data)
+        delta_n = delta / self.iteration
+        self.m1 += delta_n
 
-        self.iterative_stat.increment(np_data)
-        if self.max_order <= 1:
-            self.m1 = self.iterative_stat.get_stats()
-        else:
-            self.m1 = self.iterative_stat.get_mean()
-            self.theta2 = self.iterative_stat.get_variance()
-            self.m2 = self.theta2 + np.square(self.m1)
-
+        if self.max_order > 1:
+            self.m2 += delta * ( delta - delta_n )
         if self.max_order > 2:
-            self.m3 = self.increment_moments_mean(self.m3, np_data, 3)
+            delta_2 = delta * delta
+            delta_n_2 = delta_n * delta_n
+            self.m3 += -3.0 * delta_n * self.m2 + delta * ( delta_2 - delta_n_2 )
         if self.max_order > 3:
-            self.m4 = self.increment_moments_mean(self.m4, np_data, 4)
+            self.m4 += -4.0 * delta_n * self.m3 - 6.0 * delta_n_2 * self.m2 \
+                + delta * ( delta * delta_2 - delta_n * delta_n_2 )
 
-        # update the thetas
-        if self.iteration > 1:
-            if self.max_order > 2:
-                self.theta3 = self.m3 - 3 * self.m1 * self.m2 + 2 * np.power(self.m1, 3)
-            if self.max_order > 3:
-                self.theta4 = (
-                    self.m4 - 4 * self.m1 * self.m3 + 6 * np.square(self.m1) * self.m2
-                    - 3 * np.power(self.m1, 4)
-                )
+    def get_delta(self, moment: npt.NDArray[np.float_], np_data):
+        return np_data - moment
 
-    def increment_moments_mean(
-        self, moment: npt.NDArray[np.float_], np_data, power
-    ) -> npt.NDArray[np.float_]:
-        """
-        This function computes the iterative mean of the given moment
-        """
-        return moment + (np.power(np_data, power) - moment) / self.iteration
-
-    def get_mean(self) -> npt.NDArray[np.float_]:
+    def get_mean(self):
         return self.m1
 
-    def get_variance(self) -> npt.NDArray[np.float_]:
-        return self.theta2
+    def get_variance(self):
+        return self.m2 / self.iteration
 
-    def get_skewness(self) -> npt.NDArray[np.float_]:
-        epsilon: float = 1e-12
-        n_idx = np.where(abs(self.theta2) > epsilon)
-        skewness: npt.NDArray[np.float_] = np.zeros(len(self.theta2))
-        skewness[n_idx] = self.theta3[n_idx] / np.power(self.theta2[n_idx], 1.5)
-        return skewness
+    def get_skewness(self):
+        return self.iteration ** 0.5 * self.m3 / self.m2 ** 1.5
 
-    def get_kurtosis(self) -> npt.NDArray[np.float_]:
-        # FIXME: kurtosis is not matching scipy.stats.kurtosis
-        epsilon: float = 1e-12
-        n_idx = np.where(abs(self.theta3) > epsilon)
-        kurtosis: npt.NDArray[np.float_] = np.zeros(len(self.theta3))
-        kurtosis[n_idx] = self.theta4[n_idx] / np.power(self.theta3[n_idx], 2)
-        return kurtosis
+    def get_kurtosis(self):
+        return self.iteration * self.m4 / self.m2 ** 2
 
     def save_state(self):
         """
         This function saves the state of the moments
         """
-        mean = self.iterative_mean.save_state()
-        return {"mean": mean, "m1": self.m1,
-                "m2": self.m2, "m3": self.m3, "m4": self.m4,
-                "theta2": self.theta2, "theta3": self.theta3,
-                "theta4": self.theta4, "increment": self.iteration}
+        return {"m1": self.m1,
+                "m2": self.m2,
+                "m3": self.m3,
+                "m4": self.m4,
+                "increment": self.iteration}
 
     def load_from_state(self, state: dict):
 
-        self.iterative_stat.load_from_state(state["mean"])
         self.m1 = state["m1"]
         self.m2 = state["m2"]
         self.m3 = state["m3"]
         self.m4 = state["m4"]
-        self.theta2 = state["theta2"]
-        self.theta3 = state["theta3"]
-        self.theta4 = state["theta4"]
         self.iteration = state["increment"]

--- a/iterative_stats/iterative_moments.py
+++ b/iterative_stats/iterative_moments.py
@@ -1,0 +1,113 @@
+import numpy as np
+import numpy.typing as npt
+from iterative_stats.iterative_mean import IterativeMean
+from iterative_stats.iterative_variance import IterativeVariance
+from iterative_stats.abstract_iterative_statistics import AbstractIterativeStatistics
+
+
+class IterativeMoments(AbstractIterativeStatistics):
+    """
+    This class implements a data structure of moments similar to the one
+    in the original Melissa version
+    """
+    def __init__(self, max_order: int, **kwargs):
+        super().__init__(**kwargs)
+        self.max_order: int = max_order
+        if self.max_order <= 1:
+            self.iterative_stat = IterativeMean(self.dimension)
+        else:
+            # take lowest primitive possible to avoid duplicating
+            # the mean calculation
+            self.iterative_stat = IterativeVariance(self.dimension)
+
+        # Cascading moments depending on the requested max_order
+        self.m1: npt.NDArray[np.float_] = np.zeros(self.dimension)
+        if self.max_order > 1:
+            self.m2: npt.NDArray[np.float_] = np.zeros(self.dimension)
+            self.theta2 = np.zeros(np.size(self.dimension))
+        if self.max_order > 2:
+            self.m3: npt.NDArray[np.float_] = np.zeros(self.dimension)
+            self.theta3 = np.zeros(np.size(self.dimension))
+        if self.max_order > 3:
+            self.m4: npt.NDArray[np.float_] = np.zeros(self.dimension)
+            self.theta4 = np.zeros(self.dimension)
+
+    def increment(self, np_data: npt.NDArray[np.float_]):
+        """
+        This function increments the various orders of moments
+        """
+        self.iteration += 1
+
+        self.iterative_stat.increment(np_data)
+        if self.max_order <= 1:
+            self.m1 = self.iterative_stat.get_stats()
+        else:
+            self.m1 = self.iterative_stat.get_mean()
+            self.theta2 = self.iterative_stat.get_variance()
+            self.m2 = self.theta2 + np.square(self.m1)
+
+        if self.max_order > 2:
+            self.m3 = self.increment_moments_mean(self.m3, np_data, 3)
+        if self.max_order > 3:
+            self.m4 = self.increment_moments_mean(self.m4, np_data, 4)
+
+        # update the thetas
+        if self.iteration > 1:
+            if self.max_order > 2:
+                self.theta3 = self.m3 - 3 * self.m1 * self.m2 + 2 * np.power(self.m1, 3)
+            if self.max_order > 3:
+                self.theta4 = (
+                    self.m4 - 4 * self.m1 * self.m3 + 6 * np.square(self.m1) * self.m2
+                    - 3 * np.power(self.m1, 4)
+                )
+
+    def increment_moments_mean(
+        self, moment: npt.NDArray[np.float_], np_data, power
+    ) -> npt.NDArray[np.float_]:
+        """
+        This function computes the iterative mean of the given moment
+        """
+        return moment + (np.power(np_data, power) - moment) / self.iteration
+
+    def get_mean(self) -> npt.NDArray[np.float_]:
+        return self.m1
+
+    def get_variance(self) -> npt.NDArray[np.float_]:
+        return self.theta2
+
+    def get_skewness(self) -> npt.NDArray[np.float_]:
+        epsilon: float = 1e-12
+        n_idx = np.where(abs(self.theta2) > epsilon)
+        skewness: npt.NDArray[np.float_] = np.zeros(len(self.theta2))
+        skewness[n_idx] = self.theta3[n_idx] / np.power(self.theta2[n_idx], 1.5)
+        return skewness
+
+    def get_kurtosis(self) -> npt.NDArray[np.float_]:
+        # FIXME: kurtosis is not matching scipy.stats.kurtosis
+        epsilon: float = 1e-12
+        n_idx = np.where(abs(self.theta3) > epsilon)
+        kurtosis: npt.NDArray[np.float_] = np.zeros(len(self.theta3))
+        kurtosis[n_idx] = self.theta4[n_idx] / np.power(self.theta3[n_idx], 2)
+        return kurtosis
+
+    def save_state(self):
+        """
+        This function saves the state of the moments
+        """
+        mean = self.iterative_mean.save_state()
+        return {"mean": mean, "m1": self.m1,
+                "m2": self.m2, "m3": self.m3, "m4": self.m4,
+                "theta2": self.theta2, "theta3": self.theta3,
+                "theta4": self.theta4, "increment": self.iteration}
+
+    def load_from_state(self, state: dict):
+
+        self.iterative_stat.load_from_state(state["mean"])
+        self.m1 = state["m1"]
+        self.m2 = state["m2"]
+        self.m3 = state["m3"]
+        self.m4 = state["m4"]
+        self.theta2 = state["theta2"]
+        self.theta3 = state["theta3"]
+        self.theta4 = state["theta4"]
+        self.iteration = state["increment"]

--- a/tests/unit/test_IterativeMoments.py
+++ b/tests/unit/test_IterativeMoments.py
@@ -1,0 +1,34 @@
+import unittest
+import numpy as np
+
+
+from iterative_stats.iterative_moments import IterativeMoments
+from iterative_stats.utils.logger import logger
+import scipy.stats as stats
+
+
+class TestIterativeMoments(unittest.TestCase):
+
+    def test_increment(self):
+        # sample = np.array([10.0, 11.0, 12.0, 13.0, 16.0, -12.2, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0])
+        # set seed for reproducibility
+        np.random.seed(1234)
+        # generate 100 random numbers from normal distribution
+        sample = np.random.normal(0, 1, 40)
+        mean = np.mean(sample)
+        variance = np.var(sample,ddof=1) #compute the unbiased estimatorof the variance
+        skewness = stats.skew(sample, bias=False)
+        kurtosis = stats.kurtosis(sample, bias=False)
+
+        iterative_stats = IterativeMoments(4, dim = 1)
+        res = []
+        for x in sample :
+            res.append(x)
+            iterative_stats.increment(x)    
+        logger.info(f'{iterative_stats.get_stats()}')
+        self.assertAlmostEqual(mean, iterative_stats.get_mean()[0], delta=10e-2)
+        self.assertAlmostEqual(variance, iterative_stats.get_variance()[0], delta=10e-2)
+        self.assertAlmostEqual(skewness, iterative_stats.get_skewness()[0], delta=10e-2)
+        # FIXME: Kurtosis is incorrect - needs someone to check the equations
+        self.assertAlmostEqual(kurtosis, iterative_stats.get_kurtosis()[0], delta=10e-2)
+        self.assertEqual(iterative_stats.get_stats().shape, (1,))

--- a/tests/unit/test_IterativeMoments.py
+++ b/tests/unit/test_IterativeMoments.py
@@ -11,11 +11,10 @@ import scipy.stats as stats
 class TestIterativeMoments(unittest.TestCase):
 
     def test_increment(self):
-        # sample = np.array([10.0, 11.0, 12.0, 13.0, 16.0, -12.2, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0, 20.0])
         # set seed for reproducibility
         np.random.seed(1234)
         # generate 100 random numbers from normal distribution
-        sample = np.random.normal(0, 1, 5000)
+        sample = np.random.normal(0, 1, 500)
         mean = np.mean(sample)
         variance = np.var(sample,ddof=1) #compute the unbiased estimatorof the variance
         skewness = stats.skew(sample, bias=False)
@@ -36,7 +35,8 @@ class TestIterativeMoments(unittest.TestCase):
         self.assertAlmostEqual(skewness, ot_iter.getSkewness()[0], delta=10e-2)
         self.assertAlmostEqual(skewness, iterative_stats.get_skewness()[0], delta=10e-2)
         # FIXME: Kurtosis is incorrect - needs someone to check the equations
-        print(f"Scipy: {kurtosis}, OpenTurns: {ot_iter.getKurtosis()[0]}, Iterative: {iterative_stats.get_kurtosis()[0]}")
+        logger.info(f"Scipy: {kurtosis}, OpenTurns: {ot_iter.getKurtosis()[0]}, "
+                    f"Iterative: {iterative_stats.get_kurtosis()[0]}")
         # self.assertAlmostEqual(kurtosis, ot_iter.getKurtosis()[0], delta=10e-2)
         # self.assertAlmostEqual(kurtosis, iterative_stats.get_kurtosis()[0], delta=10e-2)
         self.assertEqual(iterative_stats.get_stats().shape, (1,))

--- a/tests/unit/test_IterativeMoments.py
+++ b/tests/unit/test_IterativeMoments.py
@@ -1,5 +1,6 @@
 import unittest
 import numpy as np
+import openturns as ot
 
 
 from iterative_stats.iterative_moments import IterativeMoments
@@ -14,21 +15,28 @@ class TestIterativeMoments(unittest.TestCase):
         # set seed for reproducibility
         np.random.seed(1234)
         # generate 100 random numbers from normal distribution
-        sample = np.random.normal(0, 1, 40)
+        sample = np.random.normal(0, 1, 5000)
         mean = np.mean(sample)
         variance = np.var(sample,ddof=1) #compute the unbiased estimatorof the variance
         skewness = stats.skew(sample, bias=False)
         kurtosis = stats.kurtosis(sample, bias=False)
 
         iterative_stats = IterativeMoments(4, dim = 1)
+        ot_iter = ot.IterativeMoments(4, 1)
         res = []
         for x in sample :
             res.append(x)
-            iterative_stats.increment(x)    
+            iterative_stats.increment(x)
+            ot_iter.increment(ot.Point([x]))
+
         logger.info(f'{iterative_stats.get_stats()}')
         self.assertAlmostEqual(mean, iterative_stats.get_mean()[0], delta=10e-2)
+        self.assertAlmostEqual(variance, ot_iter.getVariance()[0], delta=10e-2)
         self.assertAlmostEqual(variance, iterative_stats.get_variance()[0], delta=10e-2)
+        self.assertAlmostEqual(skewness, ot_iter.getSkewness()[0], delta=10e-2)
         self.assertAlmostEqual(skewness, iterative_stats.get_skewness()[0], delta=10e-2)
         # FIXME: Kurtosis is incorrect - needs someone to check the equations
-        self.assertAlmostEqual(kurtosis, iterative_stats.get_kurtosis()[0], delta=10e-2)
+        print(f"Scipy: {kurtosis}, OpenTurns: {ot_iter.getKurtosis()[0]}, Iterative: {iterative_stats.get_kurtosis()[0]}")
+        # self.assertAlmostEqual(kurtosis, ot_iter.getKurtosis()[0], delta=10e-2)
+        # self.assertAlmostEqual(kurtosis, iterative_stats.get_kurtosis()[0], delta=10e-2)
         self.assertEqual(iterative_stats.get_stats().shape, (1,))


### PR DESCRIPTION
This PR adds an  `IterativeMoments` class for obtaining the iterative moments, including the mean, variance, skewness, and kurtosis (broken for now, see below).

We need this in [Melissa](https://gitlab.inria.fr/melissa/melissa) for full backwards compatibility to continue supporting reproducibility of the original [2017 paper](https://hal.science/hal-01607479).

The equation for Kurtosis appears to be incorrect, but we simply copy pasted it verbatim from the original [Melissa implementation](https://gitlab.inria.fr/melissa/melissa-old/-/blob/master/Melissa/source/stats/general_moments.c). After further investigation, I attempted to change the class to follow OpenTurns exactly, which references [this article](https://arxiv.org/pdf/1510.04923.pdf). The error remains identical, which suggests that the original Melissa implementation is in-fact the same as OpenTurns, and both are incapable of matching Scipy non-iterative Kurtosis.

I opened an [issue over at OpenTurns](https://github.com/openturns/openturns/issues/2345) to see if they can correct the issue.

